### PR TITLE
Remove configuration for xcsoar paths

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -3,3 +3,5 @@
 OVSHELL_CONFIG=var/ovshell.conf
 OVSHELL_ROOTFS=var/rootfs
 OVSHELL_CORE_SIMULATE_DEVICE=var/rootfs/dev/sim.nmea
+XCSOAR_HOME = var/rootfs/home/root/.xcsoar
+XCSOAR_BIN = var/rootfs/usr/bin/xcsoar

--- a/src/ovshell_fileman/downloadapp.py
+++ b/src/ovshell_fileman/downloadapp.py
@@ -36,7 +36,7 @@ class LogDownloaderApp(api.App):
 
     def launch(self) -> None:
         mountwatcher = make_usbstick_watcher(self.shell.os)
-        xcsdir = self.shell.os.path(self.shell.settings.getstrict("xcsoar.home", str))
+        xcsdir = os.environ.get("XCSOAR_HOME", "/home/root/.xcsoar")
         mntdir = mountwatcher.get_mountpoint()
         downloader = DownloaderImpl(os.path.join(xcsdir, "logs"), mntdir)
 

--- a/src/ovshell_xcsoar/ext.py
+++ b/src/ovshell_xcsoar/ext.py
@@ -13,15 +13,9 @@ class XCSoarExtension(api.Extension):
     def __init__(self, id: str, shell: api.OpenVarioShell):
         self.id = id
         self.shell = shell
-        self._init_settings()
 
     def list_apps(self) -> Sequence[api.App]:
         return [XCSoarApp(self.shell)]
-
-    def _init_settings(self) -> None:
-        config = self.shell.settings
-        config.setdefault("xcsoar.binary", "//opt/XCSoar/bin/xcsoar")
-        config.setdefault("xcsoar.home", "//home/root/.xcsoar")
 
 
 class XCSoarApp(api.App):
@@ -78,10 +72,8 @@ class XCSoarApp(api.App):
         return env
 
     def _make_commandline(self) -> Sequence[str]:
-        os = self.shell.os
-        binary = os.path(self.shell.settings.getstrict("xcsoar.binary", str))
+        binary = os.environ.get("XCSOAR_BIN", "/usr/bin/xcsoar")
         return [binary, "-fly"]
-
 
 
 class AppOutputActivity(api.Activity):

--- a/src/ovshell_xcsoar/ext.py
+++ b/src/ovshell_xcsoar/ext.py
@@ -37,7 +37,6 @@ class XCSoarApp(api.App):
         self.shell.apps.pin(appinfo)
 
     def launch(self) -> None:
-        self._set_orientation_in_profile()
         env = self._prep_environment()
         cmdline = self._make_commandline()
         modal_opts = api.ModalOptions(
@@ -69,23 +68,6 @@ class XCSoarApp(api.App):
                 modal_opts,
             )
 
-    def _set_orientation_in_profile(self) -> None:
-        # Map from ovshell orientation to xcsoar orientation
-        orient_map = {
-            "0": "0",  # normal
-            "1": "1",  # portrait (90)
-            "2": "4",  # landscape (180)
-            "3": "3",  # portrait (270)
-        }
-
-        orientation = self.shell.settings.getstrict("core.screen_orientation", str)
-        xcsoar_orient = orient_map[orientation]
-
-        for prf_fname in self._find_xcsoar_profiles():
-            prf = XCSoarProfile(prf_fname)
-            prf.set_orientation(xcsoar_orient)
-            prf.save()
-
     def _prep_environment(self) -> dict[str, str]:
         env = os.environ.copy()
         lang = self.shell.settings.get("core.language", str)
@@ -100,16 +82,6 @@ class XCSoarApp(api.App):
         binary = os.path(self.shell.settings.getstrict("xcsoar.binary", str))
         return [binary, "-fly"]
 
-    def _find_xcsoar_profiles(self) -> list[str]:
-        xcs_home = self.shell.settings.getstrict("xcsoar.home", str)
-        xcs_home = self.shell.os.path(xcs_home)
-
-        profiles = []
-        for fname in os.listdir(xcs_home):
-            if fname.endswith(".prf"):
-                profiles.append(os.path.join(xcs_home, fname))
-
-        return profiles
 
 
 class AppOutputActivity(api.Activity):

--- a/tests/ovshell_fileman_tests/test_downloadapp.py
+++ b/tests/ovshell_fileman_tests/test_downloadapp.py
@@ -44,8 +44,6 @@ class LogDownloaderActivityTestbed:
 def activity_testbed(
     ovshell: testing.OpenVarioShellStub,
 ) -> LogDownloaderActivityTestbed:
-    ovshell.settings.set("xcsoar.home", "//home/xcsoar")
-
     dl = DownloaderStub()
     mw = AutomountWatcherStub()
     act = LogDownloaderActivity(ovshell, mw, dl)
@@ -54,7 +52,6 @@ def activity_testbed(
 
 def test_app_start(ovshell: testing.OpenVarioShellStub) -> None:
     # GIVEN
-    ovshell.settings.set("xcsoar.home", "//home/xcsoar")
     app = LogDownloaderApp(ovshell)
 
     # WHEN


### PR DESCRIPTION
Paths are system-dependent, so read paths from environment instead.